### PR TITLE
fix: comprehensive `detectActivePackageManager` method for pnpm support [ZEND-6808]

### DIFF
--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -45,11 +45,10 @@ async function promptExampleSelection(): Promise<string> {
     // get available templates from examples
     const availableTemplates = await getGithubFolderNames();
     // filter out the ignored ones that are listed as templates instead of examples
-    const filteredTemplates = availableTemplates
-      .filter(
-        (template) =>
-          !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
-      )
+    const filteredTemplates = availableTemplates.filter(
+      (template) =>
+        !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
+    );
     console.log(availableTemplates.length, filteredTemplates.length);
 
     // ask user to select a template from the available examples


### PR DESCRIPTION
## Purpose
We are using `detectActivePackageManager` to select a fallback package manager. Since there are multiple ways to deduce a package manager (package-lock type, package.json details, and npm_exec), I added some redundancy to `detectActivePackageManager` so that the fallback will always be found.

## Key changes
- `detectActivePackageManager` checks lock file, then package.json, then process npm_exec path.
- Corresponding tests